### PR TITLE
Fix port already in use

### DIFF
--- a/SwiftyArtNet/SwiftyArtNet.swift
+++ b/SwiftyArtNet/SwiftyArtNet.swift
@@ -31,6 +31,12 @@ class SwiftyArtNet: NSObject {
         let socket = GCDAsyncUdpSocket(delegate: self, delegateQueue: .main)
         socket.isIPv4()
         do {
+            try socket.enableReusePort(true)
+        } catch {
+            print("Error enabling reuse port")
+            throw error
+        }
+        do {
             try socket.bind(toPort: Configuration.portNumber)
         } catch {
             print("Error binding to port")


### PR DESCRIPTION
Fixes the error when the port is already in use by the system (`Address already in use`).